### PR TITLE
Fix Oktikit deprecation warning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 const Github = require('@actions/github');
-const Octokit = require('@octokit/rest').plugin(require('@octokit/plugin-retry'));
+const { Octokit } = require('@octokit/rest').plugin(require('@octokit/plugin-retry'));
 const githubToken = core.getInput('github_token', { required: true });
 const context = Github.context;
 const octokit = new Octokit({auth: githubToken});


### PR DESCRIPTION
Fix this console warning

```bash
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```